### PR TITLE
MBU Start Help Texts

### DIFF
--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/acrobat_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/acrobat_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
       music = "Tim Trance.ogg";
 	  goldTime = "25000";
       ultimateTime = "14000";
+      startHelpText = "Control your spin when you are about to land.";
    };
    new Sky(Sky) {
       sphereFront = "platinum/data/shapes/skies/wintry/front.png";
@@ -101,14 +102,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "4.5 -4.5 8";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Control your spin when you are about to land.";
    };
    new Item() {
       position = "0.162516 -0.151839 8.187";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/battlements_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/battlements_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
       music = "Tim Trance.ogg";
 	  goldTime = "45000";
       ultimateTime = "15000";
+      startHelpText = "Have fun storming the castle!";
    };
    new Sky(Sky) {
       sphereFront = "platinum/data/shapes/skies/wintry/front.png";
@@ -335,14 +336,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-16.5 -18.5 -20";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Have fun storming the castle!";
    };
    new StaticShape(EndPoint) {
       position = "-16 31.25 8";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/construction_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/construction_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
       music = "Tim Trance.ogg";
 	  goldTime = "12000";
       ultimateTime = "5000";
+      startHelpText = "Be very cautious on this framework.";
    };
    new Sky(Sky) {
       sphereFront = "platinum/data/shapes/skies/wintry/front.png";
@@ -68,14 +69,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-1.5 -14.05 16.75";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Be very cautious on this framework.";
    };
    new Item() {
       position = "-8.25 44.25 19.575";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/endurance_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/endurance_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "10";
+	 startHelpText = "Don\'t fall behind the platform - there\'s no going back!";
    };
    new Sky(Sky) {
       position = "336 136 0";
@@ -63,14 +64,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "129.5 137 6";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Don\'t fall behind the platform - there\'s no going back!";
    };
    new StaticShape(EndPoint) {
       position = "-131.5 135.5 6";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/kingofthemountain_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/kingofthemountain_ultra.mis
@@ -13,6 +13,7 @@ useUltraMarble = "1";
          music = "Tim Trance.ogg";
 	  goldTime = "44000";
       ultimateTime = "7500";
+      startHelpText = "Can you face the mountain?";
    };
    new Sky(Sky) {
       sphereFront = "platinum/data/shapes/skies/wintry/front.png";
@@ -76,14 +77,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "4.48336 -14.7998 0";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Can you face the mountain?";
    };
    new StaticShape() {
       position = "0 13 8.5";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/ordeal_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/ordeal_ultra.mis
@@ -22,6 +22,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "3";
+	 startHelpText = "Strength, speed and stealth are the keys to the trials ahead!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -136,14 +137,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-7.5 -0.5 0";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Strength, speed and stealth are the keys to the trials ahead!";
    };
    new StaticShape(EndPoint) {
       position = "74.5 42.5 20";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/reloaded_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/reloaded_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "25000";
       ultimateTime = "18000";
+      startHelpText = "Be careful when crossing between platforms.";
    };
    new Sky(Sky) {
       sphereFront = "platinum/data/shapes/skies/wintry/front.png";
@@ -68,14 +69,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "0.5 7.5 2";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Be careful when crossing between platforms.";
    };
    new StaticShape(EndPoint) {
       position = "6 -6 2";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/scaffold_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/scaffold_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "15000";
       ultimateTime = "1500";
+      text = "Keep moving to avoid falling through the trapdoors!";
    };
    new Sky(Sky) {
       sphereFront = "platinum/data/shapes/skies/wintry/front.png";
@@ -68,14 +69,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "0.5 -10 2";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Keep moving to avoid falling through the trap doors!";
    };
    new StaticShape() {
       position = "3 -10.5 6.5";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/schadenfreude_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/schadenfreude_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "85000";
       ultimateTime = "30000";
+      startHelpText = "Pay careful attention to the pattern of the bumpers.";
    };
    new Sky(Sky) {
       sphereFront = "platinum/data/shapes/skies/wintry/front.png";
@@ -104,14 +105,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "0.5 7.5 -11.5";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Pay careful attention to the pattern of the bumpers.";
    };
    new StaticShape(EndPoint) {
       position = "-10 -18.0028 -20.0016";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/selection_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/selection_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "19";
+	 startHelpText = "Don\'t fall behind!";
    };
    new Sky(Sky) {
       position = "336 136 0";
@@ -70,14 +71,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-28.5 -22.5 -28";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Don\'t fall behind!";
    };
    new StaticShape(EndPoint) {
       position = "-34.5 -18 25";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/ski_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/ski_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "18000";
       ultimateTime = "4000";
+      startHelpText = "Beginning skiers are advised to use caution.";
    };
    new Sky(Sky) {
       sphereFront = "platinum/data/shapes/skies/wintry/front.png";
@@ -61,14 +62,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-0.5 10.5 0";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Beginning skiers are advised to use caution.";
    };
    new StaticShape(EndPoint) {
       position = "-140 -284 -111";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/slickslide_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/slickslide_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "10000";
       ultimateTime = "6000";
+      startHelpText = "Watch out for bumpers!";
    };
    new Sky(Sky) {
       sphereFront = "platinum/data/shapes/skies/wintry/front.png";
@@ -68,14 +69,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "32.9 20.3 2";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Watch out for bumpers!";
    };
    new StaticShape(EndPoint) {
       position = "-107.166 1.90788 -16.0287";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/advanced/survival_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/advanced/survival_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "37000";
       ultimateTime = "25000";
+      startHelpText = "Stay on the platform to survive!";
    };
    new Sky(GlobalSky) {
       sphereFront = "platinum/data/shapes/skies/wintry/front.png";
@@ -61,14 +62,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-130.9 1.5 4";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-      text = "Stay on the platform to survive!";
    };
    new StaticShape(EndPoint) {
       position = "145.4 0 4";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/earlyfrost_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/earlyfrost_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "14";
+	 startHelpText = "Caution: Ice Ahead!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -76,14 +77,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "53.6384 -5.20118 0";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Caution: Ice Ahead!";
    };
    new StaticShape(EndPoint) {
       position = "-79.9295 -27.0818 -2.38419e-07";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/friction_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/friction_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "4";
+	 startHelpText = "Not all surfaces are the same!";
    };
    new Sky(Sky) {
       position = "336 136 0";
@@ -70,14 +71,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "2.5 -4.5 0";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Not all surfaces are the same!";
    };
    new StaticShape(EndPoint) {
       position = "16 -6 0";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/gravity_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/gravity_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "12";
+	 startHelpText = "Pick up the Gravity Modifiers to roll to the finish!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -74,14 +75,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-64.5 0.5 -2";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Pick up the Gravity Modifiers to roll to the finish!";
    };
    new StaticShape(EndPoint) {
       position = "83 -1 -2";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/gyro_train_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/gyro_train_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "9";
+	 startHelpText = "Use the Gyrocopter powerup to float across the gap safely.";
    };
    new Sky(Sky) {
       position = "336 136 0";
@@ -70,14 +71,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "123.5 1.5 56";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Use the Gyrocopter powerup to float across the gap safely.";
    };
    new Item() {
       position = "24 0 31.7686";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/halfpipe_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/halfpipe_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "18";
+	 startHelpText = "Speed around the half-pipe and collect the gems!";
    };
    new Sky(Sky) {
       position = "336 136 0";
@@ -336,14 +337,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-1.5 -15 1";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Speed around the half-pipe and collect the gems!";
    };
    new StaticShape(EndPoint) {
       position = "15.5 32 8.5";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/hazards_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/hazards_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "8";
+	 startHelpText = "Don\'t let these hazards throw you off the track to the finish!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -353,14 +354,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "10.5 -10.5 0.5";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Don\'t let these hazards throw you off the track to the finish!";
    };
    new StaticShape(EndPoint) {
       position = "2 8 38.5";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/level_five_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/level_five_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "7";
+	 startHelpText = "Build up momentum to reach the bottom quickly!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -76,14 +77,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "10.5 1.5 -2";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Build up momentum to reach the bottom quickly!";
    };
    new Item() {
       position = "-9 15 -3.5";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/level_four_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/level_four_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "6";
+	 startHelpText = "Be careful not to fall off open edges!";
    };
    new Sky(Sky) {
       position = "336 136 0";
@@ -64,14 +65,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "112.5 45.5 20";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Be careful not to fall off open edges!";
    };
    new StaticShape(EndPoint) {
       position = "-24 -42 20";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/level_six_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/level_six_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "5";
+	 startHelpText = "Touch Gravity Modifiers to change which way is down!";
    };
    new Sky(Sky) {
       position = "336 136 0";
@@ -70,14 +71,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-13.5 -22.5 0";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Touch Gravity Modifiers to change which way is down!";
    };
    new Item() {
       position = "-4 12 0";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/level_three_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/level_three_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "3";
+	 startHelpText = "You must collect the hidden gems before you may finish.";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -76,14 +77,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-23.5 11.5 0";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "You must collect the hidden gems before you may finish.";
    };
    new StaticShape(EndPoint) {
       position = "4 10 0";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/levelone_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/levelone_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "1";
+	 startHelpText = "Welcome to Marble Blast Ultra!\nUse the <func:bind moveforward>, <func:bind moveleft>, <func:bind movebackward>, <func:bind moveright> keys to roll the marble.";
    };
    new Sky(Sky) {
       position = "336 136 0";
@@ -64,14 +65,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-1.5 1.5 0";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Welcome to Marble Blast Ultra!\nUse the <func:bind moveforward>, <func:bind moveleft>, <func:bind movebackward>, <func:bind moveright> keys to roll the marble.";
    };
    new StaticShape(EndPoint) {
       position = "18 6 6.5";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/leveltwo_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/leveltwo_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "2";
+	 startHelpText = "The Super Jump powerup can be used to vault taller barriers.";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -76,14 +77,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "14.5 -0.3 0.5";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "The Super Jump powerup can be used to vault taller barriers.";
    };
    new Item() {
       position = "10.122 -2.02413 0.7";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/mptrain_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/mptrain_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "10";
+	 startHelpText = "Press the <func:bind useblast> to use the Blast power when your Blast Meter is lit.";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -233,14 +234,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "11.5 -27.5 16";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Press the <func:bind useblast> to use the Blast power when your Blast Meter is lit.";
    };
    new StaticShape(EndPoint) {
       position = "64 52 12";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/pitfall_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/pitfall_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "20000";
       ultimateTime = "13000";
+      startHelpText = "Practice your rolling skills by avoiding the gaps in the floor!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -74,14 +75,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-11.5 -16.5 0";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Practice your rolling skills by avoiding the gaps in the floor!";
    };
    new StaticShape(EndPoint) {
       position = "14 -54.5 28";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/platformparty_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/platformparty_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "30000";
       ultimateTime = "13500";
+      startHelpText = "Ride the moving platforms to reach the finish!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -71,14 +72,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-11.75 31.25 0";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Ride the moving platforms to reach the finish!";
    };
    new StaticShape(EndPoint) {
       position = "-3 42 16";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/rampmatrix_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/rampmatrix_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "30000";
       ultimateTime = "23000";
+      startHelpText = "Find 10 gems!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -270,14 +271,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-1.5 1.5 0";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Find 10 gems!";
    };
    new StaticShape(EndPoint) {
       position = "0 0 -15";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/skatePark_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/skatePark_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "33000";
       ultimateTime = "24000";
+      startHelpText = "Show off some of your crazy moves!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -74,14 +75,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-25.466 -14.0375 100.042";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Show off some of your crazy moves!";
    };
    new StaticShape(EndPoint) {
       position = "19.3242 -12.0392 99.9883";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/upward_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/upward_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "20";
+	 startHelpText = "Climb upward to reach the goal!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -112,14 +113,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "8.5 10.5 0.5";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Climb upward to reach the goal!";
    };
    new StaticShape(EndPoint) {
       position = "-1.17426 -10.1432 124.35";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/beginner/windingroad_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/beginner/windingroad_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "15000";
       ultimateTime = "11500";
+      startHelpText = "Follow the winding road, using the powerups to cross the gaps!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -74,14 +75,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-37.5 49 4";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Follow the winding road, using the powerups to cross the gaps!";
    };
    new StaticShape(EndPoint) {
       position = "-36 -36.5 24";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/aimhigh_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/aimhigh_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "10";
+	 startHelpText = "Go for the top hole!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -74,14 +75,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "10.0978 -102.654 -15.7177";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Go for the top hole!";
    };
    new StaticShape(EndPoint) {
       position = "24.6866 -14.268 -32.2177";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/gauntlet_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/gauntlet_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "35000";
       ultimateTime = "17500";
+      startHelpText = "Don't get clobbered!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -74,14 +75,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-99.5 35.5 0";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Don't get clobbered!";
    };
    new StaticShape(EndPoint) {
       position = "86 -62 41.9875";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/greatdivide_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/greatdivide_ultra.mis
@@ -64,6 +64,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "14";
+	 startHelpText = "Climb over the pass and speed down the other side!";
    };
    new Sky(Sky) {
       position = "336 136 0";
@@ -128,14 +129,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-202.5 2.5 -0.5";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Climb over the pass and speed down the other side!";
    };
    new SimGroup(MustChange_g) {
 

--- a/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/mudslide_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/mudslide_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "30000";
       ultimateTime = "12500";
+      startHelpText = "Jumping in slippery areas can help your navigation.";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -110,14 +111,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "4.91316 -8.7316 2";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Jumping in slippery areas can help your navigation.";
    };
    new StaticShape(EndPoint) {
       position = "8.5 -59 -12.5";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/plumbing_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/plumbing_ultra.mis
@@ -12,6 +12,7 @@ useUltraMarble = "1";
 	  music = "Tim Trance.ogg";
 	  goldTime = "35000";
       ultimateTime = "17500";
+      startHelpText = "Collect the gems, then speed to the finish!";
    };
    new Sky(Sky) {
       sphereFront = "platinum/data/shapes/skies/dusk/front.png";
@@ -76,14 +77,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-31.5 -12.5 4";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0 0.0 0.0 1.0 0.0 0.0 0.0 -1.0 0.0 0.0 0.0 1.0";
-      text = "Collect the gems, then speed to the finish!";
    };
    new Trigger(Bounds) {
       position = "-35 24.4553 -20.1095";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/skyscraper_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/skyscraper_ultra.mis
@@ -30,6 +30,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "5";
+	 startHelpText = "Find all the gems on your way to the top!";
    };
    new Sky(Sky) {
       position = "336 136 0";
@@ -87,14 +88,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-1.5 -0.5 2.5";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Find all the gems on your way to the top!";
    };
    new Item() {
       position = "3 13 26.0246";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/sporkintheroad_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/sporkintheroad_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "13";
+	 startHelpText = "See how quickly you can find all the gems!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -76,14 +77,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-1.5 -10.5 -1.4";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "See how quickly you can find all the gems!";
    };
    new StaticShape(EndPoint) {
       position = "-1.34749 67.545 5";

--- a/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/urban_ultra.mis
+++ b/Marble Blast Platinum/platinum/data/missions_mbu/intermediate/urban_ultra.mis
@@ -13,6 +13,7 @@ new SimGroup(MissionGroup) {
          game = "Ultra";
 useUltraMarble = "1";
          level = "2";
+	 startHelpText = "Welcome to the jungle!";
    };
    new MissionArea(MissionArea) {
       area = "-360 -648 720 1296";
@@ -363,14 +364,6 @@ useUltraMarble = "1";
          scale = "1 1 1";
          dataBlock = "StartPad";
       };
-   };
-   new Trigger() {
-      position = "-84.5 -15.5 22";
-      rotation = "1 0 0 0";
-      scale = "3 3 2";
-      dataBlock = "HelpTrigger";
-      polyhedron = "0.0000000 0.0000000 0.0000000 1.0000000 0.0000000 0.0000000 0.0000000 -1.0000000 0.0000000 0.0000000 0.0000000 1.0000000";
-         text = "Welcome to the jungle!";
    };
    new StaticShape(EndPoint) {
       position = "-83 -23 22";


### PR DESCRIPTION
The original Marble Blast Ultra had actual start help texts. The PC port created by Matt made a stupid mistake of adding help triggers disguised as start help texts on the start pad. Hypercube is the only MBU level PQ to have an actual start help text. So seeing the other levels have help triggers has start help texts is really jarring, hence why I remedied this.

(Redone with the steps you gave me. I hope I got it right this time.)