### PR TITLE
Gem Madness: Singleplayer, finish the level on OOB

### DIFF
--- a/Marble Blast Platinum/platinum/server/scripts/modes/gemMadness.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/modes/gemMadness.cs
@@ -27,7 +27,7 @@ function Mode_GemMadness::onLoad(%this) {
 	%this.registerCallback("onFoundGem");
 	%this.registerCallback("shouldRespawnGems");
 	%this.registerCallback("shouldRestartOnOOB");
-	%this.registerCallback("onOutOfBounds"); 	// main_gi: As part of a change for Singleplayer Gem Madness to instead finish the level on OOB, this is used on OOB.
+	%this.registerCallback("onOutOfBounds");
 
 	%this.registerCallback("onMissionReset");
 
@@ -92,7 +92,7 @@ function Mode_GemMadness::shouldRestartOnOOB(%this, %object) {
 	// you wouldn't restart the whole mission if someone screws up.
 	//return ($Server::ServerType $= "SinglePlayer");
 
-	// main_gi: As part of a change for Singleplayer Gem Madness to instead finish the level on OOB, this becomes false always.
+	// Making a change for Singleplayer Gem Madness to instead finish the level on OOB, this is set to always false.
 	return false;
 }
 function Mode_GemMadness::onOutOfBounds(%this, %object) {

--- a/Marble Blast Platinum/platinum/server/scripts/modes/gemMadness.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/modes/gemMadness.cs
@@ -27,6 +27,10 @@ function Mode_GemMadness::onLoad(%this) {
 	%this.registerCallback("onFoundGem");
 	%this.registerCallback("shouldRespawnGems");
 	%this.registerCallback("shouldRestartOnOOB");
+	%this.registerCallback("onOutOfBounds"); 	// main_gi: As part of a change for Singleplayer Gem Madness to instead finish the level on OOB, this is used on OOB.
+
+	%this.registerCallback("onMissionReset");
+
 	%this.registerCallback("shouldResetTime");
 	%this.registerCallback("shouldResetGem");
 	%this.registerCallback("getStartTime");
@@ -86,8 +90,18 @@ function Mode_GemMadness::shouldRestorePowerup(%this, %object) {
 function Mode_GemMadness::shouldRestartOnOOB(%this, %object) {
 	// If singleplayer, gem madness restarts. In multiplayer
 	// you wouldn't restart the whole mission if someone screws up.
-	return ($Server::ServerType $= "SinglePlayer");
+	//return ($Server::ServerType $= "SinglePlayer");
+
+	// main_gi: As part of a change for Singleplayer Gem Madness to instead finish the level on OOB, this becomes false always.
+	return false;
 }
+function Mode_GemMadness::onOutOfBounds(%this, %object) {
+	if ($Server::ServerType $= "SinglePlayer") {
+		$Game::FinishClient = %object.client;
+		endGameSetup();
+	}
+}
+
 function Mode_GemMadness::shouldResetTime(%this, %object) {
 	// The timer should reset only for singleplayer when the marble goes oob
 	return ($Server::ServerType $= "SinglePlayer");

--- a/Marble Blast Platinum/platinum/server/scripts/modes/gemMadness.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/modes/gemMadness.cs
@@ -29,8 +29,6 @@ function Mode_GemMadness::onLoad(%this) {
 	%this.registerCallback("shouldRestartOnOOB");
 	%this.registerCallback("onOutOfBounds");
 
-	%this.registerCallback("onMissionReset");
-
 	%this.registerCallback("shouldResetTime");
 	%this.registerCallback("shouldResetGem");
 	%this.registerCallback("getStartTime");
@@ -88,11 +86,7 @@ function Mode_GemMadness::shouldRestorePowerup(%this, %object) {
 	return true;
 }
 function Mode_GemMadness::shouldRestartOnOOB(%this, %object) {
-	// If singleplayer, gem madness restarts. In multiplayer
-	// you wouldn't restart the whole mission if someone screws up.
-	//return ($Server::ServerType $= "SinglePlayer");
-
-	// Making a change for Singleplayer Gem Madness to instead finish the level on OOB, this is set to always false.
+	// previously restarted on singleplayer, now oob finishes level with current score
 	return false;
 }
 function Mode_GemMadness::onOutOfBounds(%this, %object) {


### PR DESCRIPTION
In Gem Madness, it would be a better new player experience to finish the level with your current score if you go OOB, since good Gem Madness scores don't want to go OOB anyway.
It hasn't been tested in multiplayer for obvious reasons, but the code is simple enough, and should not affect multiplayer.

Technically, this is a gameplay change, and """could""" displace WRs in leaderboards, but this is an extremely minor detail, because you would need very specific level design to have it displace any current WRs (that involve OOBing to get gems).