### PR TITLE
Gem Hunt: Aim at Highest Value Gem

### DIFF
--- a/Marble Blast Platinum/platinum/server/scripts/game.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/game.cs
@@ -1437,6 +1437,37 @@ function getNearestGem(%pos) {
 	return %nearest;
 }
 
+
+function GameConnection::getHighestValueNearestGem(%this) {
+	if (isObject(%this.player)) {
+		return getHighestValueNearestGem(%this.player.getTransform());
+	}
+	return getHighestValueNearestGem("0 0 0");
+}
+
+// main_gi: New function for respawns to point at.
+function getHighestValueNearestGem(%pos) {
+	%nearest = -1;
+	%nearDist = 999999;
+	%highest = -1;
+
+	%group = ($Server::Hosting && !$Server::_Dedicated ? MissionGroup : ServerConnection);
+
+	MakeGemGroup(%group, true);
+	for (%i = 0; %i < $GemsCount; %i ++) {
+		%gem = $Gems[%i];
+		if (%gem.isHidden())
+			continue;
+		%dist = VectorDist(getWords(%gem.getTransform(), 0, 2), %pos);
+		if (%gem._huntDatablock.huntExtraValue > %highest || (%gem._huntDatablock.huntExtraValue == %highest && %dist < %nearDist)) { // Higher value, OR it's equal value but closer distance.
+			%nearest = %gem;
+			%nearDist = %dist;
+			%highest = %gem._huntDatablock.huntExtraValue;
+		}
+	}
+	return %nearest;
+}
+
 function getActivePlayerCount() {
 	%players = 0;
 	for (%i = 0; %i < ClientGroup.getCount(); %i ++) {

--- a/Marble Blast Platinum/platinum/server/scripts/modes/hunt.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/modes/hunt.cs
@@ -82,16 +82,17 @@ function Mode_hunt::onMissionReset(%this, %object) {
 		$Game::FirstSpawn = false;
 
 		//Orient all clients to face the gemspawn
+		// main_gi: I want this to point at the highest value gem.
 		for (%i = 0; %i < ClientGroup.getCount(); %i ++) {
 			%client = ClientGroup.getObject(%i);
 			if (!%client.spectating) {
-				%client.pointToNearestGem();
+				%client.pointToHighestValueNearestGem();
 			}
 		}
 	}
 }
 function Mode_hunt::onRespawnPlayer(%this, %object) {
-	%object.client.pointToNearestGem();
+	%object.client.pointToHighestValueNearestGem();
 }
 function Mode_hunt::getStartTime(%this) {
 	return (MissionInfo.time ? MissionInfo.time : 300000);

--- a/Marble Blast Platinum/platinum/server/scripts/mp/gameConnection.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/mp/gameConnection.cs
@@ -405,3 +405,29 @@ function transformToNearestGem(%gravity, %pos) {
 
 	return %angle TAB %pitch;
 }
+
+
+function GameConnection::pointToHighestValueNearestGem(%this) {
+	%pos = %this.player.getPosition();
+	%yp = transformToHighestValueNearestGem(%this.player.getGravityRot(), %pos);
+
+	%this.player.setCameraYaw(getField(%yp, 0));
+	%this.player.setCameraPitch(getField(%yp, 1));
+}
+
+function transformToHighestValueNearestGem(%gravity, %pos) {
+	%nearest = getHighestValueNearestGem(%pos);
+	if (%nearest == -1)
+		return;
+
+	%dist = VectorSub(getWords(%nearest.getTransform(), 0, 2), %pos);
+	%dist = MatrixMulVector("0 0 0" SPC RotMultiply(%gravity, "1 0 0 3.1415926"), %dist);
+
+	%angle = mAtan(getWord(%dist, 0), getWord(%dist, 1));
+
+	%dist = setWord(%dist, 2, getWord(%dist, 2) - 2);
+	%hypo = VectorLen(%dist);
+	%pitch = -mAsin((getWord(%dist, 2) / %hypo) * 0.7);
+
+	return %angle TAB %pitch;
+}


### PR DESCRIPTION
When respawning, instead of pointing at the nearest gem, this change will point it at the highest value nearest gem, which makes it faster to see and aim at blues/platinums.

The code is also rather verbose, putting an alt version of the function everywhere. I think "pointToNearestGem" is still used elsewhere, that's mostly why.

I also noticed this code occasionally doesn't work, but only on the first spawn of a level. May be related to how the game and radar sometimes doesn't show gems on the first spawn.