### PR TITLE
Leading zeros in gem counter removed, quota rainbow effect on 100%

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/playGui.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/playGui.cs
@@ -313,9 +313,11 @@ function PlayGui::updateGems(%this) {
 	if (!%max)
 		return;
 
-	if (%this.gemRainbow) {
+	if (%this.gemRainbow && %count >= %max) {
 		quotaCompleteParty();
 		%max = %this.gemRainbowNewMax; // example: on 100%, gem counter goes from 40/20 to 40/40.
+	} else {
+		cancel($quotacompleteparty);
 	}
 
 	%color = (%this.gemGreen ? $TimeColor["stopped"] : $TimeColor["normal"]);


### PR DESCRIPTION
Modifies the same file, playGui.cs, so they're in one pull request.

Leading zeros are gone: "003/006" becomes "3/6". The UI is shifted so it doesn't look like "3/ 6", and it works for Quota as well. Quota also has a new fancy hue shifting animation on getting a 100% quota (which undoes itself if you lose progress from 100% or leave the level).

Visual preview:

https://cdn.discordapp.com/attachments/701856989218603118/812179584073072730/Quota_100_Hypernova_Gem_Counter.mp4

This is a resubmission just to clean up comments and previous commit history.

