### PR TITLE
Even if animated previews are off, don't unload the level on exit

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/menu.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/menu.cs
@@ -91,6 +91,7 @@ function menuLoadMission(%file) {
 	menuSetMission(%file);
 	menuStartLoading();
 
+	$Menu::CurrentlyLoadedMission = %file;
 	$Menu::FirstLoad = false;
 	//If we need to start a server first, do so here
 	if (!$Game::Menu) {
@@ -242,12 +243,18 @@ function menuMissionExit() {
 		//Start camera loop
 		LocalClientConnection.camera.schedule(1000, moveOnPath, CameraPath1);
 	} else {
-		endMission(true);
-		//Destroy player, etc
+		// Making it so if it's off, stay in the level, just don't render the camera.
+		alxSetChannelVolume(1, 0);
+		onMissionReset();
+		MissionCleanup.add(%camera = new Camera() {
+			dataBlock = Observer;
+		});
+		%camera.setTransform(CameraPath1.getTransform());
+		%camera.scopeToClient(LocalClientConnection);
+		LocalClientConnection.setControlObject(%camera);
 		LocalClientConnection.onClientLeaveGame();
-
-		$Menu::Loaded = false;
-		$Menu::Loading = false;
+		cancelAll(LocalClientConnection);
+		menuSendCb("NewMission", $Menu::CurrentlyLoadedMission); // Show the static background image.
 	}
 
 	menuSendCb("MissionExit");


### PR DESCRIPTION
This is to make it faster if you're just exiting the level to check times and chatters.
I tested this on a poor computer with bad FPS on big levels like Maximo Center, Battlecube Finale, and others. On all of them, I got bad FPS with animate previews on, but there was no noticeable slowdown with this change other than a small slowdown when exiting the level.

This might not be optimal. What I'm doing is just not rendering the camera paths, and putting the preview image on top. I'd prefer the camera to turn completely away from the interior, as this increases FPS significantly.

Also, it does not 'update instantly' if you switch between animating previews on/off in the menu, but it's a minor problem.