### PR TITLE
Improved pause info and UI redesign - show record and egg times

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/game.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/game.cs
@@ -65,7 +65,6 @@ function clientCmdGameStart() {
 
 // Called when you respawn
 function clientCmdGameRespawn() {
-
 }
 
 function updateGameDiscordStatus() {
@@ -717,14 +716,16 @@ function reformatGameEndText() {
 	ClientMode::callback("updateEndGame");
 }
 
-function getScoreFormatting(%score, %info, %showAwesome) {
+function getScoreFormatting(%score, %info, %showAwesome, %placement) {
 	if (%info $= "")
 		%info = MissionInfo;
 	%flags = Unlock::getMissionScoreFlags(%info, %score);
 	if (%showAwesome $= "")
 		%showAwesome = $pref::ShowAwesomeHints;
 
-	if (%showAwesome && (%flags & $Completion::Awesome))
+	if (%placement == 1)
+		return "<shadow:1:1><shadowcolor:0000007F><color:0060f0>";
+	else if (%showAwesome && (%flags & $Completion::Awesome))
 		return "<shadow:1:1><shadowcolor:0000007F><color:FF4444>";
 	else if (%flags & $Completion::Ultimate)
 		return "<shadow:1:1><shadowcolor:0000007F><color:FFCC33>";

--- a/Marble Blast Platinum/platinum/client/scripts/game.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/game.cs
@@ -953,3 +953,16 @@ function formatLevel(%points, %size) {
 function formatExperience(%points) {
 	return levelDeltaPoints(pointsToLevel(%points)) - (levelTotalPoints(pointsToLevel(%points) + 1) - %points);
 }
+
+function removeLeadingZerosFromTime(%time) { // 00:25.45 -> 25.45
+	if (getSubStr(%time, 0, 1) $= "0" && %time !$= "0") { // %time !$= "0" just checks that it's not a score.
+		if (getSubStr(%time, 1, 1) $= "0") {
+			if (getSubStr(%time, 3, 1) $= "0") {
+				return getSubStr(%time, 4, 10);
+			}
+			return getSubStr(%time, 3, 10); // 3, not 2, to remove the colon too
+		}
+		return getSubStr(%time, 1, 10);
+	}
+	return %time;
+}

--- a/Marble Blast Platinum/platinum/client/scripts/mp/commands.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/mp/commands.cs
@@ -121,6 +121,9 @@ function clientCmdUpdateMarbleShape(%marble) {
 function clientCmdFoundEgg(%time, %eggName, %eggPickup) {
 	PlayGui.showEggTime(%time);
 
+	statsGetTopScoreModes(PlayMissionGui.getMissionInfo()); // For the egg on pause screen.
+	$Game::GotEggThisSession = true;
+	
 	//Record the egg
 	$Game::EasterEgg = true;
 

--- a/Marble Blast Platinum/platinum/client/scripts/mp/commands.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/mp/commands.cs
@@ -123,7 +123,7 @@ function clientCmdFoundEgg(%time, %eggName, %eggPickup) {
 
 	statsGetTopScoreModes(PlayMissionGui.getMissionInfo()); // For the egg on pause screen.
 	$Game::GotEggThisSession = true;
-	
+
 	//Record the egg
 	$Game::EasterEgg = true;
 

--- a/Marble Blast Platinum/platinum/client/scripts/mp/commands.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/mp/commands.cs
@@ -121,7 +121,10 @@ function clientCmdUpdateMarbleShape(%marble) {
 function clientCmdFoundEgg(%time, %eggName, %eggPickup) {
 	PlayGui.showEggTime(%time);
 
-	statsGetTopScoreModes(PlayMissionGui.getMissionInfo()); // For the egg on pause screen.
+	if (lb()) {
+		statsGetTopScoreModes(PlayMissionGui.getMissionInfo()); // For the egg on pause screen.
+	}
+
 	$Game::GotEggThisSession = true;
 
 	//Record the egg

--- a/Marble Blast Platinum/platinum/client/ui/ExitGameDlg.gui
+++ b/Marble Blast Platinum/platinum/client/ui/ExitGameDlg.gui
@@ -133,7 +133,7 @@ new GuiControl(ExitGameDlg) {
 				profile = "GuiMLTextProfile";
 				horizSizing = "left";
 				vertSizing = "bottom";
-				position = "238 51"; // 50% of 500, -12
+				position = "238 51"; // 50% of 500, then -12
 				extent = "150 32";
 				minExtent = "8 8";
 				visible = "1";
@@ -549,7 +549,7 @@ function ExitGameDlg::onWake(%this) {
 	%eggRecordTitle = "<shadow:1:1><shadowcolor:000000bf>" @ %eggThemeColor @ "Egg Record";
 
 	//Get the world record
-	%record = false;
+	%record = -1;
 	if (lb()) {
 		
 		%cache = PlayMissionGui.globalScoreCache[PlayMissionGui.getMissionInfo().id];
@@ -576,7 +576,7 @@ function ExitGameDlg::onWake(%this) {
 	%info = PlayMissionGui.getMissionInfo();
 	%pbType = getField($hs[0], 0);
 	%pbLabel = %pbType == 0 ? removeLeadingZerosFromTime(formatTime(getField($hs[0], 1))) : formatScore(getField($hs[0], 1));
-	%pbColor = getScoreFormatting($hs[0], %info, "", (%record == getField($hs[0], 1))? 1 : 2); // Technically no record (offline) and score of 0 counts as a record, but PB should not show in that case.
+	%pbColor = getScoreFormatting($hs[0], %info, "", (%record == getField($hs[0], 1))? 1 : 2); // If record is unset, it would be -1 and never trigger.
 	%pbEggLabel = removeLeadingZerosFromTime(formatTime(getField($hs["egg"], 0)));
 
 	%eggThemeColor = (%game $= "PlatinumQuest") ? "<color:cccc99>" : "<color:4580ff>";

--- a/Marble Blast Platinum/platinum/client/ui/ExitGameDlg.gui
+++ b/Marble Blast Platinum/platinum/client/ui/ExitGameDlg.gui
@@ -87,12 +87,253 @@ new GuiControl(ExitGameDlg) {
 				bitmap = "./loading/loading_main_text";
 				wrap = "0";
 			};
+			new GuiMLTextCtrl(ExitGameInfoTitle) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "center";
+				vertSizing = "bottom";
+				position = "150 0"; // "center" with horizontal position does nothing. This is actually at 238.
+				extent = "500 24";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+				wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoLeftmostChallengeTitle) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "28 51"; // 28 (40 - 12). values 28 168 238 308 448
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoLeftcenterChallengeTitle) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "168 51"; // 28 + 140
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoCenterChallengeTitle) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "238 51"; // 50% of 500, -12
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoRightcenterChallengeTitle) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "308 51"; // 28 + 140 + 140
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoRightmostChallengeTitle) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "448 51"; // 28 + 140 + 140 + 140
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoLeftmostChallengeTime) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "28 71";
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoLeftcenterChallengeTime) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "168 71";
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoCenterChallengeTime) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "238 71";
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoRightcenterChallengeTime) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "308 71";
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoRightmostChallengeTime) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "448 71";
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoPersonalBestTitle) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "238 106";
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoPersonalBestTime) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "238 126";
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+
+
+			new GuiMLTextCtrl(ExitGameInfoPersonalBestModeTitle) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "28 106";
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoPersonalBestModeTime) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "28 126";
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoRecordModeTitle) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "448 106";
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+			new GuiMLTextCtrl(ExitGameInfoRecordModeTime) {
+				profile = "GuiMLTextProfile";
+				horizSizing = "left";
+				vertSizing = "bottom";
+				position = "448 126";
+				extent = "150 32";
+				minExtent = "8 8";
+				visible = "1";
+				helpTag = "0";
+				lineSpacing = "2";
+				allowColorChars = "0";
+				maxChars = "-1";
+					wrap = "0";
+			};
+
 			new GuiMLTextCtrl(ExitGameInfo) {
 				profile = "GuiMLTextProfile";
 				horizSizing = "center";
 				vertSizing = "bottom";
-				position = "150 0";
-				extent = "500 74";
+				position = "200 100";
+				extent = "500 50";
 				minExtent = "8 8";
 				visible = "1";
 				helpTag = "0";
@@ -210,7 +451,9 @@ function ExitGameDlg::end() {
 function ExitGameDlg::onWake(%this) {
 	%info = getMissionInfo($Client::MissionFile);
 
-	%text = "<shadow:1:1><shadowcolor:000000bf><just:center>" @ shrinkToFit(%info.name, $DefaultFont["Bold"], 42, 24, getWord(ExitGameInfo.getExtent(), 0)) @ "<font:32>";
+	%title = "<shadow:1:1><shadowcolor:000000bf><just:center>" @ shrinkToFit(%info.name, $DefaultFont["Bold"], 42, 24, getWord(ExitGameInfo.getExtent(), 0));
+	ExitGameInfoTitle.setText(%title);
+	%text = "<shadow:1:1><shadowcolor:000000bf><font:32>";
 
 	%showAwesome = ((Unlock::getMissionCompletion(%info) & $Completion::Awesome) == $Completion::Awesome) || $Unlock::DisplayAll;
 
@@ -302,30 +545,149 @@ function ExitGameDlg::onWake(%this) {
 		%awesomeTitle = "<shadow:1:1><shadowcolor:000000bf><color:FF4444>Awesome";
 	}
 
-	%parText      = %parTitle;
-	%goldText     = %goldTitle;
-	%platinumText = %platinumTitle;
-	%ultimateText = %ultimateTitle;
-	%awesomeText  = %awesomeTitle;
+	%recordTitle   = "<shadow:1:1><shadowcolor:000000bf><color:0060f0>Record";
+	%eggRecordTitle = "<shadow:1:1><shadowcolor:000000bf><color:4580ff>Egg Record";
 
-	//Par can have both time and score
-	if (ClientMode::callbackForMission(%info, "timeMultiplier", 1) > 0) {
-		if (%parTimeLabel !$= "N/A") {
-			%text = %text NL "<just:left><spush>" @ %parText @ ":<spop><just:right>" @ %parTimeLabel;
+	//Get the world record
+	%record = false;
+	if (lb()) {
+		
+		%cache = PlayMissionGui.globalScoreCache[PlayMissionGui.getMissionInfo().id];
+		if (isObject(%cache)) {
+			%scores = %cache.scores;
+			if (%scores.getSize()) {
+				%record = %scores.getEntry(0).score;
+				%recordType = %scores.getEntry(0).score_type;
+				%recordLabel = (%recordType $= "time" ? formatTime(%record) : formatScore(%record));
+			}
+		}
+
+		%cache = PlayMissionGui.globalScoreModeCache[PlayMissionGui.getMissionInfo().id]; 
+		if (isObject(%cache)) {
+			%scores = %cache.getFieldValue("egg").scores; // Egg scores
+			if (%scores.getSize()) {
+				%eggRecordLabel = formatTime(%scores.getEntry(0).time);
+			}
 		}
 	}
-	if (%parScoreLabel !$= "N/A") {
-		%text = %text NL "<just:left><spush>" @ %parTitle SPC "Score:<spop><just:right>" @ %parScoreLabel;
+	%challengeTitles = "";
+	%challengeTimes = "";
+
+	%info = PlayMissionGui.getMissionInfo();
+	%pbType = getField($hs[0], 0);
+	%pbLabel = %pbType == 0 ? formatTime(getField($hs[0], 1)) : formatScore(getField($hs[0], 1));
+	%pbColor = getScoreFormatting($hs[0], %info, "", (%record == getField($hs[0], 1))? 1 : 2);
+	%pbEggLabel = formatTime(getField($hs["egg"], 0));
+
+	%pbTitle = "<shadow:1:1><shadowcolor:000000bf>Personal Best";
+	%pbEggTitle = "<shadow:1:1><shadowcolor:000000bf><color:4580ff>Egg Best";
+
+	ExitGameInfoPersonalBestTitle.setText("<just:center><font:24>" @ %pbColor @ %pbTitle);
+	ExitGameInfoPersonalBestTime.setText("<just:center><font:32>" @ %pbLabel);
+
+	if ($Game::GotEggThisSession) {
+		ExitGameInfoPersonalBestModeTitle.setText("<just:center><font:24>" @ %pbEggTitle);
+		ExitGameInfoPersonalBestModeTime.setText("<just:center><font:32>" @ %pbEggLabel);
+		ExitGameInfoRecordModeTitle.setText("<just:center><font:24>" @ %eggRecordTitle);
+		ExitGameInfoRecordModeTime.setText("<just:center><font:32>" @ %eggRecordLabel);
+		ExitGameInfoPersonalBestModeTitle.setVisible(true);
+		ExitGameInfoPersonalBestModeTime.setVisible(true);
+		ExitGameInfoRecordModeTitle.setVisible(true);
+		ExitGameInfoRecordModeTime.setVisible(true);
+	} else {
+		ExitGameInfoPersonalBestModeTitle.setVisible(false);
+		ExitGameInfoPersonalBestModeTime.setVisible(false);
+		ExitGameInfoRecordModeTitle.setVisible(false);
+		ExitGameInfoRecordModeTime.setVisible(false);
 	}
 
 	//Show what we need to
-	if (%goldTitle     !$= "" && %goldLabel     !$= "N/A") %text = %text NL "<just:left><spush>" @ %goldText @ ":<spop><just:right>" @ %goldLabel;
-	if (%platinumTitle !$= "" && %platinumLabel !$= "N/A") %text = %text NL "<just:left><spush>" @ %platinumText @ ":<spop><just:right>" @ %platinumLabel;
-	if (%ultimateTitle !$= "" && %ultimateLabel !$= "N/A") %text = %text NL "<just:left><spush>" @ %ultimateText @ ":<spop><just:right>" @ %ultimateLabel;
-
-	if (%showAwesome) {
-		if (%awesomeTitle !$= "" && %awesomeLabel !$= "N/A") %text = %text NL "<just:left><spush>" @ %awesomeText @ ":<spop><just:right>" @ %awesomeLabel;
+	if (ClientMode::callbackForMission(%info, "timeMultiplier", 1) > 0 && (%parTimeLabel !$= "N/A")) {	//Par can have both time and score
+		%challengeTitles = %challengeTitles SPC "<just:center><font:24>" @ %parTitle;
+		%challengeTimes  = %challengeTimes  SPC "<just:center><font:32>" @ %parTimeLabel;
+	} else if (%parScoreLabel !$= "N/A") { // It shouldn't be possible to have both at once though
+		%challengeTitles = %challengeTitles SPC "<just:center><font:24>" @ %parTitle;
+		%challengeTimes  = %challengeTimes  SPC "<just:center><font:32>" @ %parScoreLabel;
 	}
+
+	if (%goldTitle     !$= "" && %goldLabel     !$= "N/A") {
+		%challengeTitles = %challengeTitles SPC "<just:center><font:24>" @ %goldTitle;
+		%challengeTimes  = %challengeTimes  SPC "<just:center><font:32>" @ %goldLabel;
+	}
+	if (%platinumTitle !$= "" && %platinumLabel !$= "N/A") {
+		%challengeTitles = %challengeTitles SPC "<just:center><font:24>" @ %platinumTitle;
+		%challengeTimes  = %challengeTimes  SPC "<just:center><font:32>" @ %platinumLabel;
+	}
+	if (%ultimateTitle !$= "" && %ultimateLabel !$= "N/A") {
+		%challengeTitles = %challengeTitles SPC "<just:center><font:24>" @ %ultimateTitle;
+		%challengeTimes  = %challengeTimes  SPC "<just:center><font:32>" @ %ultimateLabel;
+	}
+	if (%showAwesome && %awesomeTitle !$= "" && %awesomeLabel !$= "N/A") {
+		%challengeTitles = %challengeTitles SPC "<just:center><font:24>" @ %awesomeTitle;
+		%challengeTimes  = %challengeTimes  SPC "<just:center><font:32>" @ %awesomeLabel;
+	}
+
+	if (lb() && (%showAwesome || $LBPref::ShowRecords) && (%recordLabel !$= "")) {
+		%challengeTitles = %challengeTitles SPC "<just:center><font:24>" @ %recordTitle;
+		%challengeTimes  = %challengeTimes  SPC "<just:center><font:32>" @ %recordLabel;
+	}
+	%challengeTitles = ltrim(%challengeTitles); // trim the first space
+	%challengeTimes = ltrim(%challengeTimes);
+	%challengeLength = getWordCount(%challengeTitles);
+
+	// The display is size 1 through 4, and there are five unique positionings (left, l-center, center, r-center, right). Get rid of some of these times if our PB is higher.
+	// ----- 1 -----
+	// 1 --------- 2
+	// 1 --- 2 --- 3
+	// 1 - 2 - 3 - 4
+
+
+	if (%challengeLength == 1) {
+		ExitGameInfoCenterChallengeTitle.setText(%challengeTitles);
+		ExitGameInfoCenterChallengeTime.setText(%challengeTimes);
+	} else if (%challengeLength == 2) {
+		ExitGameInfoLeftmostChallengeTitle.setText(getWord(%challengeTitles, 0));
+		ExitGameInfoLeftmostChallengeTime.setText(getWord(%challengeTimes, 0));
+		ExitGameInfoRightmostChallengeTitle.setText(getWord(%challengeTitles, 1));
+		ExitGameInfoRightmostChallengeTime.setText(getWord(%challengeTimes, 1));
+	} else if (%challengeLength == 3) {
+		ExitGameInfoLeftmostChallengeTitle.setText(getWord(%challengeTitles, 0));
+		ExitGameInfoLeftmostChallengeTime.setText(getWord(%challengeTimes, 0));
+		ExitGameInfoCenterChallengeTitle.setText(getWord(%challengeTitles, 1));
+		ExitGameInfoCenterChallengeTime.setText(getWord(%challengeTimes, 1));
+		ExitGameInfoRightmostChallengeTitle.setText(getWord(%challengeTitles, 2));
+		ExitGameInfoRightmostChallengeTime.setText(getWord(%challengeTimes, 2));
+	} else if (%challengeLength == 4) {
+		ExitGameInfoLeftmostChallengeTitle.setText(getWord(%challengeTitles, 0));
+		ExitGameInfoLeftmostChallengeTime.setText(getWord(%challengeTimes, 0));
+		ExitGameInfoLeftcenterChallengeTitle.setText(getWord(%challengeTitles, 1));
+		ExitGameInfoLeftcenterChallengeTime.setText(getWord(%challengeTimes, 1));
+		ExitGameInfoRightcenterChallengeTitle.setText(getWord(%challengeTitles, 2));
+		ExitGameInfoRightcenterChallengeTime.setText(getWord(%challengeTimes, 2));
+		ExitGameInfoRightmostChallengeTitle.setText(getWord(%challengeTitles, 3));
+		ExitGameInfoRightmostChallengeTime.setText(getWord(%challengeTimes, 3));
+	} else if (%challengeLength >= 5) { // Meaning it's all five, par, platinum, ultimate, awesome, record - prerequisite for this if-condition is %showAwesome, which means the player already beat awesome, so hide platinum. Par could be hidden too, but that one seems more relevant to me.
+		ExitGameInfoLeftmostChallengeTitle.setText(getWord(%challengeTitles, 0));
+		ExitGameInfoLeftmostChallengeTime.setText(getWord(%challengeTimes, 0));
+		ExitGameInfoLeftcenterChallengeTitle.setText(getWord(%challengeTitles, 2));
+		ExitGameInfoLeftcenterChallengeTime.setText(getWord(%challengeTimes, 2));
+		ExitGameInfoRightcenterChallengeTitle.setText(getWord(%challengeTitles, 3));
+		ExitGameInfoRightcenterChallengeTime.setText(getWord(%challengeTimes, 3));
+		ExitGameInfoRightmostChallengeTitle.setText(getWord(%challengeTitles, 4));
+		ExitGameInfoRightmostChallengeTime.setText(getWord(%challengeTimes, 4));
+	}
+	ExitGameInfoCenterChallengeTitle.setVisible(%challengeLength == 1 || %challengeLength == 3);
+	ExitGameInfoCenterChallengeTime.setVisible(%challengeLength == 1 || %challengeLength == 3);
+	ExitGameInfoLeftmostChallengeTitle.setVisible(%challengeLength != 1);
+	ExitGameInfoLeftmostChallengeTime.setVisible(%challengeLength != 1);
+	ExitGameInfoRightmostChallengeTitle.setVisible(%challengeLength != 1);
+	ExitGameInfoRightmostChallengeTime.setVisible(%challengeLength != 1);
+	ExitGameInfoLeftcenterChallengeTitle.setVisible(%challengeLength >= 4);
+	ExitGameInfoLeftcenterChallengeTime.setVisible(%challengeLength >= 4);
+	ExitGameInfoRightcenterChallengeTitle.setVisible(%challengeLength >= 4);
+	ExitGameInfoRightcenterChallengeTime.setVisible(%challengeLength >= 4);
+
+
 
 	%text = %text NL "";
 

--- a/Marble Blast Platinum/platinum/client/ui/ExitGameDlg.gui
+++ b/Marble Blast Platinum/platinum/client/ui/ExitGameDlg.gui
@@ -576,14 +576,22 @@ function ExitGameDlg::onWake(%this) {
 	%info = PlayMissionGui.getMissionInfo();
 	%pbType = getField($hs[0], 0);
 	%pbLabel = %pbType == 0 ? formatTime(getField($hs[0], 1)) : formatScore(getField($hs[0], 1));
-	%pbColor = getScoreFormatting($hs[0], %info, "", (%record == getField($hs[0], 1))? 1 : 2);
+	%pbColor = getScoreFormatting($hs[0], %info, "", (%record == getField($hs[0], 1))? 1 : 2); // Technically no record (offline) and score of 0 counts as a record, but PB should not show in that case.
 	%pbEggLabel = formatTime(getField($hs["egg"], 0));
 
 	%pbTitle = "<shadow:1:1><shadowcolor:000000bf>Personal Best";
 	%pbEggTitle = "<shadow:1:1><shadowcolor:000000bf><color:4580ff>Egg Best";
 
-	ExitGameInfoPersonalBestTitle.setText("<just:center><font:24>" @ %pbColor @ %pbTitle);
-	ExitGameInfoPersonalBestTime.setText("<just:center><font:32>" @ %pbLabel);
+	if ((%pbType == 0 && getSubStr(%pbLabel, 0, 5) $= "99:59") || (%pbType == 1 && getField($hs[0], 1) == 0)) {
+		ExitGameInfoPersonalBestTitle.setVisible(false);
+		ExitGameInfoPersonalBestTime.setVisible(false);
+	} else {
+		ExitGameInfoPersonalBestTitle.setText("<just:center><font:24>" @ %pbColor @ %pbTitle);
+		ExitGameInfoPersonalBestTime.setText("<just:center><font:32>" @ %pbLabel);
+		ExitGameInfoPersonalBestTitle.setVisible(true);
+		ExitGameInfoPersonalBestTime.setVisible(true);
+	}
+
 
 	if ($Game::GotEggThisSession) {
 		ExitGameInfoPersonalBestModeTitle.setText("<just:center><font:24>" @ %pbEggTitle);

--- a/Marble Blast Platinum/platinum/client/ui/ExitGameDlg.gui
+++ b/Marble Blast Platinum/platinum/client/ui/ExitGameDlg.gui
@@ -458,11 +458,11 @@ function ExitGameDlg::onWake(%this) {
 	%showAwesome = ((Unlock::getMissionCompletion(%info) & $Completion::Awesome) == $Completion::Awesome) || $Unlock::DisplayAll;
 
 	//Challenge times
-	%parTimeLabel      = (%info.time         ? formatTime(%info.time)         : "N/A");
-	%goldTimeLabel     = (%info.goldTime     ? formatTime(%info.goldTime)     : "N/A");
-	%platinumTimeLabel = (%info.platinumTime ? formatTime(%info.platinumTime) : "N/A");
-	%ultimateTimeLabel = (%info.ultimateTime ? formatTime(%info.ultimateTime) : "N/A");
-	%awesomeTimeLabel  = (%info.awesomeTime  ? formatTime(%info.awesomeTime)  : "N/A");
+	%parTimeLabel      = (%info.time         ? removeLeadingZerosFromTime(formatTime(%info.time))         : "N/A");
+	%goldTimeLabel     = (%info.goldTime     ? removeLeadingZerosFromTime(formatTime(%info.goldTime))     : "N/A");
+	%platinumTimeLabel = (%info.platinumTime ? removeLeadingZerosFromTime(formatTime(%info.platinumTime)) : "N/A");
+	%ultimateTimeLabel = (%info.ultimateTime ? removeLeadingZerosFromTime(formatTime(%info.ultimateTime)) : "N/A");
+	%awesomeTimeLabel  = (%info.awesomeTime  ? removeLeadingZerosFromTime(formatTime(%info.awesomeTime))  : "N/A");
 	//Challenge scores
 	%parScoreLabel      = (%info.score         !$= "" ? formatScore(%info.score)         : "N/A");
 	%goldScoreLabel     = (%info.goldScore     !$= "" ? formatScore(%info.goldScore)     : "N/A");
@@ -546,7 +546,7 @@ function ExitGameDlg::onWake(%this) {
 	}
 
 	%recordTitle   = "<shadow:1:1><shadowcolor:000000bf><color:0060f0>Record";
-	%eggRecordTitle = "<shadow:1:1><shadowcolor:000000bf><color:4580ff>Egg Record";
+	%eggRecordTitle = "<shadow:1:1><shadowcolor:000000bf>" @ %eggThemeColor @ "Egg Record";
 
 	//Get the world record
 	%record = false;
@@ -558,7 +558,7 @@ function ExitGameDlg::onWake(%this) {
 			if (%scores.getSize()) {
 				%record = %scores.getEntry(0).score;
 				%recordType = %scores.getEntry(0).score_type;
-				%recordLabel = (%recordType $= "time" ? formatTime(%record) : formatScore(%record));
+				%recordLabel = (%recordType $= "time" ? removeLeadingZerosFromTime(formatTime(%record)) : formatScore(%record));
 			}
 		}
 
@@ -566,7 +566,7 @@ function ExitGameDlg::onWake(%this) {
 		if (isObject(%cache)) {
 			%scores = %cache.getFieldValue("egg").scores; // Egg scores
 			if (%scores.getSize()) {
-				%eggRecordLabel = formatTime(%scores.getEntry(0).time);
+				%eggRecordLabel = removeLeadingZerosFromTime(formatTime(%scores.getEntry(0).time));
 			}
 		}
 	}
@@ -575,14 +575,16 @@ function ExitGameDlg::onWake(%this) {
 
 	%info = PlayMissionGui.getMissionInfo();
 	%pbType = getField($hs[0], 0);
-	%pbLabel = %pbType == 0 ? formatTime(getField($hs[0], 1)) : formatScore(getField($hs[0], 1));
+	%pbLabel = %pbType == 0 ? removeLeadingZerosFromTime(formatTime(getField($hs[0], 1))) : formatScore(getField($hs[0], 1));
 	%pbColor = getScoreFormatting($hs[0], %info, "", (%record == getField($hs[0], 1))? 1 : 2); // Technically no record (offline) and score of 0 counts as a record, but PB should not show in that case.
-	%pbEggLabel = formatTime(getField($hs["egg"], 0));
+	%pbEggLabel = removeLeadingZerosFromTime(formatTime(getField($hs["egg"], 0)));
+
+	%eggThemeColor = (%game $= "PlatinumQuest") ? "<color:cccc99>" : "<color:4580ff>";
 
 	%pbTitle = "<shadow:1:1><shadowcolor:000000bf>Personal Best";
-	%pbEggTitle = "<shadow:1:1><shadowcolor:000000bf><color:4580ff>Egg Best";
+	%pbEggTitle = "<shadow:1:1><shadowcolor:000000bf>" @ %eggThemeColor @ "Egg Best";
 
-	if ((%pbType == 0 && getSubStr(%pbLabel, 0, 5) $= "99:59") || (%pbType == 1 && getField($hs[0], 1) == 0)) {
+	if (getField($hs[0], 2) $= "Matan W." && (%pbType == 0 && getSubStr(%pbLabel, 0, 5) $= "99:59") || (%pbType == 1 && getField($hs[0], 1) == 0)) {
 		ExitGameInfoPersonalBestTitle.setVisible(false);
 		ExitGameInfoPersonalBestTime.setVisible(false);
 	} else {
@@ -596,12 +598,18 @@ function ExitGameDlg::onWake(%this) {
 	if ($Game::GotEggThisSession) {
 		ExitGameInfoPersonalBestModeTitle.setText("<just:center><font:24>" @ %pbEggTitle);
 		ExitGameInfoPersonalBestModeTime.setText("<just:center><font:32>" @ %pbEggLabel);
-		ExitGameInfoRecordModeTitle.setText("<just:center><font:24>" @ %eggRecordTitle);
-		ExitGameInfoRecordModeTime.setText("<just:center><font:32>" @ %eggRecordLabel);
 		ExitGameInfoPersonalBestModeTitle.setVisible(true);
 		ExitGameInfoPersonalBestModeTime.setVisible(true);
-		ExitGameInfoRecordModeTitle.setVisible(true);
-		ExitGameInfoRecordModeTime.setVisible(true);
+		if (lb()) {
+			ExitGameInfoRecordModeTitle.setText("<just:center><font:24>" @ %eggThemeColor @ %eggRecordTitle);
+			ExitGameInfoRecordModeTime.setText("<just:center><font:32>" @ %eggRecordLabel);
+			ExitGameInfoRecordModeTitle.setVisible(true);
+			ExitGameInfoRecordModeTime.setVisible(true);
+		} else {
+			ExitGameInfoRecordModeTitle.setVisible(false);
+			ExitGameInfoRecordModeTime.setVisible(false);
+		}
+
 	} else {
 		ExitGameInfoPersonalBestModeTitle.setVisible(false);
 		ExitGameInfoPersonalBestModeTime.setVisible(false);
@@ -645,7 +653,7 @@ function ExitGameDlg::onWake(%this) {
 
 	// The display is size 1 through 4, and there are five unique positionings (left, l-center, center, r-center, right). Get rid of some of these times if our PB is higher.
 	// ----- 1 -----
-	// 1 --------- 2
+	// --- 2 - 3 ---
 	// 1 --- 2 --- 3
 	// 1 - 2 - 3 - 4
 
@@ -654,10 +662,10 @@ function ExitGameDlg::onWake(%this) {
 		ExitGameInfoCenterChallengeTitle.setText(%challengeTitles);
 		ExitGameInfoCenterChallengeTime.setText(%challengeTimes);
 	} else if (%challengeLength == 2) {
-		ExitGameInfoLeftmostChallengeTitle.setText(getWord(%challengeTitles, 0));
-		ExitGameInfoLeftmostChallengeTime.setText(getWord(%challengeTimes, 0));
-		ExitGameInfoRightmostChallengeTitle.setText(getWord(%challengeTitles, 1));
-		ExitGameInfoRightmostChallengeTime.setText(getWord(%challengeTimes, 1));
+		ExitGameInfoLeftcenterChallengeTitle.setText(getWord(%challengeTitles, 0));
+		ExitGameInfoLeftcenterChallengeTime.setText(getWord(%challengeTimes, 0));
+		ExitGameInfoRightcenterChallengeTitle.setText(getWord(%challengeTitles, 1));
+		ExitGameInfoRightcenterChallengeTime.setText(getWord(%challengeTimes, 1));
 	} else if (%challengeLength == 3) {
 		ExitGameInfoLeftmostChallengeTitle.setText(getWord(%challengeTitles, 0));
 		ExitGameInfoLeftmostChallengeTime.setText(getWord(%challengeTimes, 0));
@@ -686,14 +694,14 @@ function ExitGameDlg::onWake(%this) {
 	}
 	ExitGameInfoCenterChallengeTitle.setVisible(%challengeLength == 1 || %challengeLength == 3);
 	ExitGameInfoCenterChallengeTime.setVisible(%challengeLength == 1 || %challengeLength == 3);
-	ExitGameInfoLeftmostChallengeTitle.setVisible(%challengeLength != 1);
-	ExitGameInfoLeftmostChallengeTime.setVisible(%challengeLength != 1);
-	ExitGameInfoRightmostChallengeTitle.setVisible(%challengeLength != 1);
-	ExitGameInfoRightmostChallengeTime.setVisible(%challengeLength != 1);
-	ExitGameInfoLeftcenterChallengeTitle.setVisible(%challengeLength >= 4);
-	ExitGameInfoLeftcenterChallengeTime.setVisible(%challengeLength >= 4);
-	ExitGameInfoRightcenterChallengeTitle.setVisible(%challengeLength >= 4);
-	ExitGameInfoRightcenterChallengeTime.setVisible(%challengeLength >= 4);
+	ExitGameInfoLeftmostChallengeTitle.setVisible(%challengeLength >= 3);
+	ExitGameInfoLeftmostChallengeTime.setVisible(%challengeLength >= 3);
+	ExitGameInfoRightmostChallengeTitle.setVisible(%challengeLength >= 3);
+	ExitGameInfoRightmostChallengeTime.setVisible(%challengeLength >= 3);
+	ExitGameInfoLeftcenterChallengeTitle.setVisible(%challengeLength == 2 || %challengeLength >= 4);
+	ExitGameInfoLeftcenterChallengeTime.setVisible(%challengeLength == 2 || %challengeLength >= 4);
+	ExitGameInfoRightcenterChallengeTitle.setVisible(%challengeLength == 2 || %challengeLength >= 4);
+	ExitGameInfoRightcenterChallengeTime.setVisible(%challengeLength == 2 || %challengeLength >= 4);
 
 
 

--- a/Marble Blast Platinum/platinum/server/scripts/game.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/game.cs
@@ -714,7 +714,7 @@ function GameConnection::onClientLeaveGame(%this) {
 		%this.player.iceShard.getDatablock().unfreeze(%this.player.iceShard, %this.player, true);
 	}
 	
-	$Game::GotEggThisSession = false;
+	$Game::GotEggThisSession = false; // main_gi: For the egg on pause screen.
 
 	cancel(%this.stateSchedule);
 

--- a/Marble Blast Platinum/platinum/server/scripts/game.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/game.cs
@@ -713,8 +713,8 @@ function GameConnection::onClientLeaveGame(%this) {
 	if (%this.player.isFrozen) {
 		%this.player.iceShard.getDatablock().unfreeze(%this.player.iceShard, %this.player, true);
 	}
-
-	$Game::GotEggThisSession = false; // main_gi: For the egg on pause screen.
+	
+	$Game::GotEggThisSession = false;
 
 	cancel(%this.stateSchedule);
 
@@ -1434,37 +1434,6 @@ function getNearestGem(%pos) {
 		if (%dist < %nearDist) {
 			%nearest = %gem;
 			%nearDist = %dist;
-		}
-	}
-	return %nearest;
-}
-
-
-function GameConnection::getHighestValueNearestGem(%this) {
-	if (isObject(%this.player)) {
-		return getHighestValueNearestGem(%this.player.getTransform());
-	}
-	return getHighestValueNearestGem("0 0 0");
-}
-
-// main_gi: New function for respawns to point at.
-function getHighestValueNearestGem(%pos) {
-	%nearest = -1;
-	%nearDist = 999999;
-	%highest = -1;
-
-	%group = ($Server::Hosting && !$Server::_Dedicated ? MissionGroup : ServerConnection);
-
-	MakeGemGroup(%group, true);
-	for (%i = 0; %i < $GemsCount; %i ++) {
-		%gem = $Gems[%i];
-		if (%gem.isHidden())
-			continue;
-		%dist = VectorDist(getWords(%gem.getTransform(), 0, 2), %pos);
-		if (%gem._huntDatablock.huntExtraValue > %highest || (%gem._huntDatablock.huntExtraValue == %highest && %dist < %nearDist)) { // Higher value, OR it's equal value but closer distance.
-			%nearest = %gem;
-			%nearDist = %dist;
-			%highest = %gem._huntDatablock.huntExtraValue;
 		}
 	}
 	return %nearest;

--- a/Marble Blast Platinum/platinum/server/scripts/game.cs
+++ b/Marble Blast Platinum/platinum/server/scripts/game.cs
@@ -714,6 +714,8 @@ function GameConnection::onClientLeaveGame(%this) {
 		%this.player.iceShard.getDatablock().unfreeze(%this.player.iceShard, %this.player, true);
 	}
 
+	$Game::GotEggThisSession = false; // main_gi: For the egg on pause screen.
+
 	cancel(%this.stateSchedule);
 
 	if (isObject(%this.camera))
@@ -1432,6 +1434,37 @@ function getNearestGem(%pos) {
 		if (%dist < %nearDist) {
 			%nearest = %gem;
 			%nearDist = %dist;
+		}
+	}
+	return %nearest;
+}
+
+
+function GameConnection::getHighestValueNearestGem(%this) {
+	if (isObject(%this.player)) {
+		return getHighestValueNearestGem(%this.player.getTransform());
+	}
+	return getHighestValueNearestGem("0 0 0");
+}
+
+// main_gi: New function for respawns to point at.
+function getHighestValueNearestGem(%pos) {
+	%nearest = -1;
+	%nearDist = 999999;
+	%highest = -1;
+
+	%group = ($Server::Hosting && !$Server::_Dedicated ? MissionGroup : ServerConnection);
+
+	MakeGemGroup(%group, true);
+	for (%i = 0; %i < $GemsCount; %i ++) {
+		%gem = $Gems[%i];
+		if (%gem.isHidden())
+			continue;
+		%dist = VectorDist(getWords(%gem.getTransform(), 0, 2), %pos);
+		if (%gem._huntDatablock.huntExtraValue > %highest || (%gem._huntDatablock.huntExtraValue == %highest && %dist < %nearDist)) { // Higher value, OR it's equal value but closer distance.
+			%nearest = %gem;
+			%nearDist = %dist;
+			%highest = %gem._huntDatablock.huntExtraValue;
 		}
 	}
 	return %nearest;


### PR DESCRIPTION
Significantly improves the pause menu in terms of showing times, by showing the record and, if you got an egg in the same session you're playing the level, shows the egg times, which will be hidden again once you leave that level. This takes up no more vertical space than before.

Thousandths work and there is no overlap and there is plenty of spacing. However it doesn't update instantly when you switch to thousandths in the pause menu, you have to close and reopen.

![unknown](https://user-images.githubusercontent.com/43479839/110737672-cd88c880-81fb-11eb-98ae-1f0f62af978c.png)
![unknown2](https://user-images.githubusercontent.com/43479839/110737678-d11c4f80-81fb-11eb-8a6b-0a4dbea0c6eb.png)
![unknown3](https://user-images.githubusercontent.com/43479839/110737682-d2e61300-81fb-11eb-8a1e-eb092bbee5f7.png)
![unknown4](https://user-images.githubusercontent.com/43479839/110737687-d4afd680-81fb-11eb-8623-6753e5ee0a4e.png)



