### PR TITLE
Animate Background -> Preload Levels

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/optionsGui.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/optionsGui.cs
@@ -297,7 +297,7 @@ $Options::Name    ["Graphics", $i++] = "interiorShaders";
 $Options::Title   ["Graphics", $i  ] = "Material Quality";
 $Options::Type    ["Graphics", $i  ] = "value";
 $Options::Name    ["Graphics", $i++] = "animateBackground";
-$Options::Title   ["Graphics", $i  ] = "Animate Background";
+$Options::Title   ["Graphics", $i  ] = "Preload Levels";
 $Options::Type    ["Graphics", $i  ] = "boolean";
 if (canSupportAntiAliasing()) { //This is not available on mac
 	$Options::Name ["Graphics", $i++] = "antiAliasing";


### PR DESCRIPTION
When I first played PQ, I was literally trying to find a way to disable this level-loads-on-level-click due to how much lag it was causing, **and I could not find it**. This makes Animate Background a really uninformative name because it looks purely visual when it makes a mechanical change, one that can cause a lot of lag.