### PR TITLE
(Bugfix) Message hud patch, blast bar

### DIFF
--- a/Marble Blast Platinum/platinum/client/scripts/messagehud.cs
+++ b/Marble Blast Platinum/platinum/client/scripts/messagehud.cs
@@ -88,7 +88,7 @@ function PlayGui::positionMessageHud(%this) {
 	PlayGuiContent.setVisible(!(%hideTimer || %isEndGame));
 	PG_AchievementListBox.setVisible(!%hideTimer);
 	PG_BlastBar.setVisible(shouldEnableBlast());
-	%blastY = getWord(VectorSub(PlayGui.getExtent(), (lb() && !%hideChat ? "0 155" : "0 35")), 1);
+	%blastY = getWord(VectorSub(PlayGui.getExtent(), (lb() && !%hideChat ? "0" SPC (35 + (20 * $LBPref::ChatMessageSize)) : "0 35")), 1);
 	PG_BlastBar.setPosition(6 SPC %blastY);
 
 	PG_MessageListBox.setHeight(%h - 100 - (lb() && !%hideChat ? 100 : 0) - (shouldEnableBlast() ? 34 : 0));


### PR DESCRIPTION
This is directly related to my previous "ingame lines of chat" thing. I just missed the blast bar needed to move as well.