### PR TITLE
Kaboomization Nest Egg Hint

### DIFF
--- a/Marble Blast Platinum/platinum/data/lbmissions_custom/levelpacks60-69/Kaboomization.mis
+++ b/Marble Blast Platinum/platinum/data/lbmissions_custom/levelpacks60-69/Kaboomization.mis
@@ -14,7 +14,7 @@ new SimGroup(MissionGroup) {
          level = "21";
          music = "Waves in the Dark.ogg";
          name = "Kaboomization";
-         nestEggHint = "One of those landmine dispensers has a false bottom and jumping into it will get you to a lousy homemade minigame on the roof. \nFurther explanations will be given when you get there.";
+         nestEggHint = "One of those landmine dispensers has a false wall and jumping into it will get you to a lousy homemade minigame on the roof. \nFurther explanations will be given when you get there.";
          platinumTime = "80000";
          startHelpText = "A landmine is even more powerful than usual when it\'s moving, so be on the lookout!";
 		 trivia = "To get the first version of this level, take out most of the scenery, the \"vertical\" landmine dispensers, shorten the second water pool. \nFeeling that the level is bland as heck, I went \"oh gosh, it's so bland, let's throw lots of scenery!\" \nThis level has been left without updates for 5 months.";


### PR DESCRIPTION
Changed the nest egg hint a bit to reflect reality and to eliminate confusion.

Before: One of those landmine dispensers has a false bottom and jumping into it will get you to a lousy homemade minigame on the roof.

After: One of those landmine dispensers has a false wall and jumping into it will get you to a lousy homemade minigame on the roof.